### PR TITLE
Add push and pull handlers

### DIFF
--- a/src/Infra/CommandHandler/CommandHandlers.cs
+++ b/src/Infra/CommandHandler/CommandHandlers.cs
@@ -41,6 +41,8 @@ namespace WinAppDriver.Infra.CommandHandler
       { Command.SetWindowSize, new SetWindowSizeHandler() },
       { Command.TakeScreenshot, new TakeScreenshotHandler() },
       { Command.ClickOnElement, new ClickHandler() },
+      { Command.DevicePushFile, new DevicePushFileHandler() },
+      { Command.DevicePullFile, new DevicePullFileHandler() }
     };
 
     public object ExecuteCommand(Command command, ISessionManager sessionManager, string sessionId, object req, string elementId)

--- a/src/Infra/CommandHandler/ICommandHandlers.cs
+++ b/src/Infra/CommandHandler/ICommandHandlers.cs
@@ -37,6 +37,8 @@ namespace WinAppDriver.Infra.CommandHandler
     MaximizeWindow,
     TakeScreenshot,
     ClickOnElement,
+    DevicePushFile,
+    DevicePullFile
   }
 
   public interface ICommandHandlers

--- a/src/Infra/Infra.csproj
+++ b/src/Infra/Infra.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>WinAppDriver.Infra</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Windows.Apps.Test" Version="1.0.181205002" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Infra/Request/SessionReqs.cs
+++ b/src/Infra/Request/SessionReqs.cs
@@ -68,4 +68,10 @@ namespace WinAppDriver
 
     public double height;
   }
+
+  public class PathFileReq
+  {
+    public string path { get; set; }
+    public string data { get; set; }
+  }
 }

--- a/src/WinAppDriver/Controllers/SessionController.cs
+++ b/src/WinAppDriver/Controllers/SessionController.cs
@@ -396,6 +396,20 @@ namespace WinAppDriver.Controllers
     }
 
     [HttpPost]
+    [Route("{sessionId}/appium/device/push_file")]
+    public IActionResult SessionDevicePushFile(string sessionId, [FromBody] object content)
+    {
+      return ExecuteCommand(Command.DevicePushFile, sessionId, content, null);
+    }
+
+    [HttpPost]
+    [Route("{sessionId}/appium/device/pull_file")]
+    public IActionResult SessionDevicePullFile(string sessionId, [FromBody] object content)
+    {
+      return ExecuteCommand(Command.DevicePullFile, sessionId, content, null);
+    }
+
+    [HttpPost]
     [Route("{sessionId}/moveto")]
     public IActionResult SessionMoveTo(string sessionId, [FromBody] object content)
     {

--- a/src/WinAppDriver/WinAppDriver.csproj
+++ b/src/WinAppDriver/WinAppDriver.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Version Condition=" '$(Version)' == '' ">0.2.2.0</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
@@ -11,10 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.9" />
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.5" />
-    <PackageReference Include="NSwag.AspNetCore" Version="13.8.2" />
-    <PackageReference Include="Serilog.Extensions.Logging.File" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.14" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
+    <PackageReference Include="NSwag.AspNetCore" Version="13.18.2" />
+    <PackageReference Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WinAppDriver/publish.bat
+++ b/src/WinAppDriver/publish.bat
@@ -1,2 +1,2 @@
-del /f /q /s bin\Release\netcoreapp3.1\win-x64
+del /f /q /s bin\Release\net6.0\win-x64
 dotnet publish -c Release  -r win-x64

--- a/test/Infra.UnitTest/Infra.UnitTest.csproj
+++ b/test/Infra.UnitTest/Infra.UnitTest.csproj
@@ -1,19 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Moq" Version="4.14.7" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="FluentAssertions" Version="6.10.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/WinAppDriver.IntegrationTest/DeviceTest.cs
+++ b/test/WinAppDriver.IntegrationTest/DeviceTest.cs
@@ -1,0 +1,160 @@
+﻿using FluentAssertions;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Razor;
+using Newtonsoft.Json.Linq;
+using WinAppDriver.Infra;
+using WinAppDriver.Infra.Request;
+using WinAppDriver.Infra.Result;
+using Xunit;
+
+namespace WinAppDriver.IntegrationTest
+{
+  [Collection("Sequential")]
+  public class DeviceTest: IDisposable
+  {
+    public readonly string _tempDirectory;
+    public readonly string _uniqueTempDirectory;
+
+    public DeviceTest()
+    {
+      _tempDirectory = Path.GetTempPath();
+      _uniqueTempDirectory = Path.Combine(_tempDirectory, Guid.NewGuid().ToString());
+
+      Directory.CreateDirectory(_uniqueTempDirectory);
+    }
+
+    [Theory]
+    [InlineData("file.bin")]
+    [InlineData("foo\\bar\\file.bin")]
+    public async Task Test_PushFile_UploadFileToRemote(string partialFilePath)
+    {
+      using (var client = new TestClientProvider().Client)
+      {
+        var sessionId = await Helpers.CreateNewSession(client, AppIds.WinVer);
+        sessionId.Should().NotBeNullOrEmpty();
+
+        try
+        {
+          var fileContent = Guid.NewGuid().ToByteArray();
+          var filePath = Path.Combine(_uniqueTempDirectory, partialFilePath);
+
+          var res = await Helpers.PostSessionMessage<object, PathFileReq>(client, sessionId, "appium/device/push_file",
+            new PathFileReq() { data = Convert.ToBase64String(fileContent), path = filePath });
+
+          res.statusCode.Should().Be(HttpStatusCode.OK);
+
+          File.Exists(filePath).Should().BeTrue();
+          (await File.ReadAllBytesAsync(filePath)).Should().BeEquivalentTo(fileContent);
+        }
+        finally
+        {
+
+          await Helpers.DeletSession(client, sessionId);
+        }
+      }
+    }
+
+    [Theory]
+    [InlineData("", "content", "Invalid path: Null or whitespace")] // path empty 
+    [InlineData("C:\\file.bin", "", "Invalid file content: Null or whitespace")] // empty content
+    [InlineData("C:\\file.bin", "???????", "The input is not a valid Base-64 string as it contains a non-base 64 character, more than two padding characters, or an illegal character among the padding characters.")] // invalid content
+    public async Task Test_PushFile_InvalidPayload(string filePath, string fileContent, string errorMessage)
+    {
+      using (var client = new TestClientProvider().Client)
+      {
+        var sessionId = await Helpers.CreateNewSession(client, AppIds.WinVer);
+        sessionId.Should().NotBeNullOrEmpty();
+
+        try
+        {
+          var res = await Helpers.PostSessionMessage<object, PathFileReq>(client, sessionId, "appium/device/push_file",
+            new PathFileReq() { data = fileContent, path = filePath });
+
+          res.statusCode.Should().Be(HttpStatusCode.InternalServerError);
+          res.value.Should().BeOfType<JObject>();
+
+          var resValue = (JObject)res.value;
+          
+          resValue.Value<string>("error").Should().BeEquivalentTo("UnknownError");
+          resValue.Value<string>("message").Should().BeEquivalentTo(errorMessage);
+        }
+        finally
+        {
+          await Helpers.DeletSession(client, sessionId);
+        }
+      }
+    }
+
+    [Fact]
+    public async Task Test_PullFile_DownloadFileFromRemote()
+    {
+      using (var client = new TestClientProvider().Client)
+      {
+        var sessionId = await Helpers.CreateNewSession(client, AppIds.WinVer);
+        sessionId.Should().NotBeNullOrEmpty();
+
+        try
+        {
+          var fileContent = Guid.NewGuid().ToByteArray();
+          var filePath = Path.Combine(_uniqueTempDirectory, "file.bin");
+          File.WriteAllBytes(filePath, fileContent);
+
+          var res = await Helpers.PostSessionMessage<object, PathFileReq>(client, sessionId, "appium/device/pull_file",
+            new PathFileReq() { path = filePath });
+
+          res.statusCode.Should().Be(HttpStatusCode.OK);
+          res.value.Should().BeEquivalentTo(Convert.ToBase64String(fileContent));
+        }
+        finally
+        {
+
+          await Helpers.DeletSession(client, sessionId);
+        }
+      }
+    }
+
+    [Theory]
+    [InlineData("", "Invalid path: Null or whitespace")] // path empty 
+    [InlineData("C:\\file.bin", "The requested file doesn't exist.")] // file doesn't exist
+    public async Task Test_PullFile_InvalidPayload(string filePath, string errorMessage)
+    {
+      using (var client = new TestClientProvider().Client)
+      {
+        var sessionId = await Helpers.CreateNewSession(client, AppIds.WinVer);
+        sessionId.Should().NotBeNullOrEmpty();
+
+        try
+        {
+          var res = await Helpers.PostSessionMessage<object, PathFileReq>(client, sessionId, "appium/device/pull_file",
+            new PathFileReq() { path = filePath });
+
+          res.statusCode.Should().Be(HttpStatusCode.InternalServerError);
+          res.value.Should().BeOfType<JObject>();
+
+          var resValue = (JObject)res.value;
+
+          resValue.Value<string>("error").Should().BeEquivalentTo("UnknownError");
+          resValue.Value<string>("message").Should().BeEquivalentTo(errorMessage);
+        }
+        finally
+        {
+          await Helpers.DeletSession(client, sessionId);
+        }
+      }
+    }
+
+    public void Dispose()
+    {
+      if (Directory.Exists(_uniqueTempDirectory))
+      {
+        Directory.Delete(_uniqueTempDirectory, true);
+      }
+    }
+  }
+}

--- a/test/WinAppDriver.IntegrationTest/Helpers.cs
+++ b/test/WinAppDriver.IntegrationTest/Helpers.cs
@@ -32,6 +32,7 @@ namespace WinAppDriver.IntegrationTest
     public const string Edge = "Microsoft.MicrosoftEdge_8wekyb3d8bbwe!MicrosoftEdge";
     public const string AlarmClock = "Microsoft.WindowsAlarms_8wekyb3d8bbwe!App";
     public const string Notepad = "c:\\windows\\system32\\notepad.exe";
+    public const string WinVer = "C:\\Windows\\System32\\winver.exe";
   }
   class Helpers
   {

--- a/test/WinAppDriver.IntegrationTest/WinAppDriver.IntegrationTest.csproj
+++ b/test/WinAppDriver.IntegrationTest/WinAppDriver.IntegrationTest.csproj
@@ -1,17 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="FluentAssertions" Version="6.10.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.14" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/WinAppDriver.UnitTest/WinAppDriver.UnitTest.csproj
+++ b/test/WinAppDriver.UnitTest/WinAppDriver.UnitTest.csproj
@@ -1,18 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Moq" Version="4.14.7" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="FluentAssertions" Version="6.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi @licanhua,

This PR adds two new handlers:
* [Pull File](https://appium.io/docs/en/commands/device/files/pull-file/)
* [Push File](https://appium.io/docs/en/commands/device/files/push-file/)

All clients should happily use these routes and work out of the box.

I also upgraded all dependencies and .net version to 6.0 because .net core 3.1 is eol.
I also added e2e tests for both handlers which cover the happy path and error cases.

Beside that I have noticed that tests based on notepad.exe fail because the "remastered" notepad for windows 11 has a multi-process design (i think). The session creation fails because the created process is not the one with the ui. Pretty tricky use case. `winver` works as expected.

I would be great if you could review my PR and give feedback.